### PR TITLE
Add email address string support to setRecipients

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -157,15 +157,17 @@ class Message( object ):
 		val: the one argument this method takes can be very flexible. you can send:
 			a dictionary: this must to be a dictionary formated as such:
 				{"EmailAddress":{"Address":"recipient@example.com"}}
-				with other options such ass "Name" with address. but at minimum it must have this.
-			a list: this must to be a list of libraries formatted the way specified above,
-				or it can be a list of dictionary objects of type Contact or it can be an email address as string. 
-				The method will sort out the libraries from the contacts. 
+				with other options such ass "Name" with address. but at minimum
+				it must have this.
+			a list: this must to be a list of libraries formatted the way 
+				specified above, or it can be a list of dictionary objects of
+				type Contact or it can be an email address as string. The 
+				method will sort out the libraries from the contacts. 
 			a string: this is if you just want to throw an email address. 
 			a contact: type Contact from this dictionary. 
 			a group: type Group, which is a list of contacts.
-		For each of these argument types the appropriate action will be taken to fit them to the 
-		needs of the library.
+		For each of these argument types the appropriate action will be taken
+		to fit them to the needs of the library.
 		'''
 		self.json['ToRecipients'] = []
 		if isinstance(val,list):

--- a/O365/message.py
+++ b/O365/message.py
@@ -159,8 +159,8 @@ class Message( object ):
 				{"EmailAddress":{"Address":"recipient@example.com"}}
 				with other options such ass "Name" with address. but at minimum it must have this.
 			a list: this must to be a list of libraries formatted the way specified above,
-				or it can be a list of dictionary objects of type Contact. The method will sort
-				out the libraries from the contacts. 
+				or it can be a list of dictionary objects of type Contact or it can be an email address as string. 
+				The method will sort out the libraries from the contacts. 
 			a string: this is if you just want to throw an email address. 
 			a contact: type Contact from this dictionary. 
 			a group: type Group, which is a list of contacts.
@@ -172,7 +172,10 @@ class Message( object ):
 			for con in val:
 				if isinstance(con,Contact):
 					self.addRecipient(con)
-				else:
+				elif isinstance(con, str):
+					if '@' in con:
+						self.addRecipient(con)
+				elif isinstance(con, dict):
 					self.json['ToRecipients'].append(con)
 		elif isinstance(val,dict):
 			self.json['ToRecipients'] = [val]


### PR DESCRIPTION
Enable support for email address to be passed in as a list of strings in setRecipients. As in issue #25.