### PR TITLE
[Fix] Add group to event

### DIFF
--- a/O365/event.py
+++ b/O365/event.py
@@ -1,4 +1,5 @@
 from O365.contact import Contact
+from O365.group import Group
 import logging
 import json
 import requests


### PR DESCRIPTION
Event makes use of the group module on line 318 of this file. It was never imported and so that caused an error. Added group to the imports, this should relieve the issue.