### PR TITLE
Add event settings for timezones and type of event

### DIFF
--- a/O365/event.py
+++ b/O365/event.py
@@ -1,4 +1,5 @@
 from O365.contact import Contact
+from O365.group import Group
 import logging
 import json
 import requests
@@ -29,6 +30,9 @@ class Event( object ):
 		setStart -- sets the starting time of the event. (struct_time)
 		setEnd -- sets the starting time of the event. (struct_time)
 		setAttendees -- sets the attendee list.
+		setStartTimeZone -- sets the timezone for the start of the event item.
+                setEndTimeZone -- sets the timezone for the end of the event item.
+                setType -- sets the type of meeting (required or not) for an event.
 		
 	Variables:
 		time_string -- Formated time string for translation to and from json.
@@ -267,7 +271,7 @@ class Event( object ):
 			#your time string!
 			self.json['End'] = val
 
-	def setAttendee(self,val):
+	def setAttendees(self,val):
 		'''
 		set the attendee list.
 		
@@ -298,6 +302,18 @@ class Event( object ):
 		else:
 			return False
 		return True
+	
+        def setStartTimeZone(self,val):
+                '''sets event start timezone'''
+                self.json['StartTimeZone'] = val
+
+        def setEndTimeZone(self,val):
+                '''sets event end timezone'''
+                self.json['EndTimeZone'] = val
+
+        def setType(self,val):
+                '''sets event type'''
+                self.json['Type'] = val	
 
 	def addAttendee(self,address,name=None):
 		'''

--- a/O365/event.py
+++ b/O365/event.py
@@ -32,7 +32,6 @@ class Event( object ):
 		setAttendees -- sets the attendee list.
 		setStartTimeZone -- sets the timezone for the start of the event item.
                 setEndTimeZone -- sets the timezone for the end of the event item.
-                setType -- sets the type of meeting (required or not) for an event.
 		
 	Variables:
 		time_string -- Formated time string for translation to and from json.
@@ -310,10 +309,6 @@ class Event( object ):
         def setEndTimeZone(self,val):
                 '''sets event end timezone'''
                 self.json['EndTimeZone'] = val
-
-        def setType(self,val):
-                '''sets event type'''
-                self.json['Type'] = val	
 
 	def addAttendee(self,address,name=None):
 		'''


### PR DESCRIPTION
Fix: Function description is SetAttendees while the function was named SetAttendee. Renamed the function to match the description
Add: Ability to set the timezone for the start of the meeting
Add: Ability to set the timezone for the end of the meeting
Add: Missing import for group, this is called by event.py to create a group object.
vent makes use of the group module on line 333 of this file. It was never imported and so that caused an error. Added group to the imports, this should relieve the issue.