### PR TITLE
Add try/except for JSON body key

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -238,9 +238,15 @@ class Message( object ):
 		val -- Default: None. The content of the body you want set. If you don't pass a
 			value it is just ignored. 
 		'''
-		self.json['Body']['ContentType'] = 'HTML'
-		if val:
-			self.json['Body']['Content'] = val
-
+		cont = False
+		
+		while not cont:
+			try:
+				self.json['Body']['ContentType'] = 'HTML'
+				if val:
+					self.json['Body']['Content'] = val
+				cont = True
+			except:
+				self.json['Body'] = {}
 
 #To the King!


### PR DESCRIPTION
*NOT TESTED*

In regards to https://github.com/Narcolapser/python-o365/issues/43, I added the same try/catch that is in setBody, which will set the "Body" JSON key if it is not already set.