### PR TITLE
Moved Inbox verify variable to be assigned before getMessages call

### DIFF
--- a/O365/inbox.py
+++ b/O365/inbox.py
@@ -30,13 +30,11 @@ class Inbox( object ):
 		self.messages = []
 
 		self.filters = ''
+		self.verify = verify
 		
 		if getNow:
 			self.filters = 'IsRead eq false'
 			self.getMessages()
-
-		self.verify = verify
-
 
 	def getMessages(self, number = 10):
 		'''


### PR DESCRIPTION
Currently on an Inbox instance initialization, if getNow is set to True, it leads to an attribute error on Line 53 since self.verify is defined after the call to getMessages().