### PR TITLE
replace reciev -> receiv (spelling fix)

### DIFF
--- a/O365/fluent_message.py
+++ b/O365/fluent_message.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class Message(object):
     '''
-    Management of the process of sending, recieving, reading, and editing emails.
+    Management of the process of sending, receiving, reading, and editing emails.
 
     Note: the get and set methods are technically superflous. You can get more through control over
     a message you are trying to craft throught he use of editing the message.json, but these
@@ -45,7 +45,7 @@ class Message(object):
 
     def __init__(self, json=None, auth=None, verify=True):
         '''
-        Makes a new message wrapper for sending and recieving messages.
+        Makes a new message wrapper for sending and receiving messages.
 
         Keyword Arguments:
                         json (default = None) -- Takes json if you have a pre-existing message to create from.
@@ -64,7 +64,7 @@ class Message(object):
 
         self.auth = auth
         self.attachments = []
-        self.reciever = None
+        self.receiver = None
 
         self.verify = verify
 

--- a/O365/message.py
+++ b/O365/message.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class Message(object):
 	'''
-	Management of the process of sending, recieving, reading, and editing emails.
+	Management of the process of sending, receiving, reading, and editing emails.
 
 	Note: the get and set methods are technically superflous. You can get more through control over
 	a message you are trying to craft throught he use of editing the message.json, but these
@@ -44,7 +44,7 @@ class Message(object):
 
 	def __init__(self, json=None, auth=None, verify=True):
 		'''
-		Makes a new message wrapper for sending and recieving messages.
+		Makes a new message wrapper for sending and receiving messages.
 
 		Keyword Arguments:
 						json (default = None) -- Takes json if you have a pre-existing message to create from.
@@ -63,7 +63,7 @@ class Message(object):
 
 		self.auth = auth
 		self.attachments = []
-		self.reciever = None
+		self.receiver = None
 
 		self.verify = verify
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ for att in m.attachments:
 	processAttachment(att,resp)
 #various un-related bits left out for brevity.
 ```
-The attachment class stores the files as base64 encoded files. But this doesn't matter to you! The attachment class can work with you if you want to just send/recieve raw binary or base64. You can also just give it a path to a file if you want to creat an attachment:
+The attachment class stores the files as base64 encoded files. But this doesn't matter to you! The attachment class can work with you if you want to just send/receive raw binary or base64. You can also just give it a path to a file if you want to creat an attachment:
 ```python
 att = Attachment(path=path)
 ```


### PR DESCRIPTION
corrects all instances and variations of 'recieve' to 'receive'.
affects `Message` attribute "reciever" but is otherwise just in docstrings.